### PR TITLE
Fix disasmtool_lix no_color option

### DIFF
--- a/disasmtool_lix/disasmtool.cpp
+++ b/disasmtool_lix/disasmtool.cpp
@@ -267,9 +267,9 @@ void print_instruction(const size_t rip, INSTRUX *instrux, const options &opts)
                 printf("%02x", instrux->InstructionBytes[k]);
             }
         }
-    }
 
-    _set_text_color(Reset);
+        _set_text_color(Reset);
+    }
 
     for (; k < instrux->Length; k++)
     {


### PR DESCRIPTION
Hi,

I just encountered and tried to fixed a remaining ANSI reset sequence with `--no-color` option.

One can visualize the bug with `./disasmtool_lix/build/disasmtool --bits 64 --no-color -f /tmp/file.o | head -n 1 | xxd`

```diff
1c1
< 00000000: 3020 1b5b 6d37 6634 3520 2020 2020 2020  0 .[m7f45
---
> 00000000: 3020 3766 3435 2020 2020 2020 2020 2020  0 7f45
3,4c3,4
< 00000020: 2020 2020 204a 4e4c 4520 2020 2020 2030       JNLE      0
< 00000030: 7834 370a                                x47.
---
> 00000020: 2020 4a4e 4c45 2020 2020 2020 3078 3437    JNLE      0x47
> 00000030: 0a                                       .
```
I haven't tested the windows version.