### PR TITLE
Fix the disasmtool_lix build

### DIFF
--- a/disasmtool_lix/CMakeLists.txt
+++ b/disasmtool_lix/CMakeLists.txt
@@ -79,8 +79,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
 
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-O1")
 
-if (CMAKE_COMPILER_IS_GNUCC)
-  if (NOT (CMAKE_C_COMPILER_VERSION LESS 6.0))
+if (CMAKE_COMPILER_IS_GNUCXX)
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 6.0))
     add_compile_options(
       -Wshift-overflow=2
       -Wnull-dereference
@@ -90,7 +90,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
       )
   endif()
 
-  if (NOT (CMAKE_C_COMPILER_VERSION LESS 7.0))
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.0))
     add_compile_options(
       -Wdangling-else
       -Wshadow=global
@@ -98,7 +98,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
       )
   endif()
 
-  if (NOT (CMAKE_C_COMPILER_VERSION LESS 8.0))
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 8.0))
     add_compile_options(
       -Wmultistatement-macros
       -Warray-bounds=2
@@ -116,33 +116,139 @@ if (CMAKE_COMPILER_IS_GNUCC)
       -Wcast-qual
       -Wcast-align
       -Wparentheses
-      -Wjump-misses-init
       -Wfloat-conversion
-      -Wmissing-prototypes
       -Wredundant-decls
       -Wdisabled-optimization
       -Woverlength-strings
+      -Wswitch-enum
       -fstack-clash-protection
       -static
       )
   endif()
-else()
+
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 9.0))
+    add_compile_options(
+      -Wcatch-value=2
+      -Wduplicated-branches
+      -Wextra-semi
+      -Wif-not-aligned
+      -Wplacement-new=2
+      -Wsuggest-override
+      -Wunused-but-set-parameter
+      -Wswitch-enum
+      -Wuseless-cast
+      )
+    endif()
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   add_compile_options(
     -Wno-missing-braces
     )
 
-  if (NOT (CMAKE_C_COMPILER_VERSION LESS 6.0))
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 6.0))
     add_compile_options(
       -Wshift-overflow
       -Wnull-dereference
       -Wvla
       -Wdangling-else
-      -Wshadow
       -Wpragmas
       -Wtautological-compare
       -Wzero-as-null-pointer-constant
       )
   endif()
+
+  if (NOT (CMAKE_CXX_COMPILER_VERSION LESS 10.0))
+    add_compile_options(
+      -Warray-bounds-pointer-arithmetic
+      -Wassign-enum
+      -Watomic-implicit-seq-cst
+      -Watomic-properties
+      -Wauto-import
+      -Wbad-function-cast
+      -Wbind-to-temporary-copy
+      -Wbitfield-enum-conversion
+      -Wbitwise-op-parentheses
+      -Wcomma
+      -Wconditional-uninitialized
+      -Wconsumed
+      -Wcstring-format-directive
+      -Wctad-maybe-unsupported
+      -Wcustom-atomic-properties
+      -Wdelete-non-abstract-non-virtual-dtor
+      -Wdeprecated-copy
+      -Wdeprecated-copy-dtor
+      -Wdeprecated-dynamic-exception-spec
+      -Wdeprecated-implementations
+      -Wdouble-promotion
+      -Wduplicate-enum
+      -Wduplicate-method-arg
+      -Wduplicate-method-match
+      -Wembedded-directive
+      -Wempty-init-stmt
+      -Wexit-time-destructors
+      -Wexplicit-ownership-type
+      -Wextra-semi
+      -Wfloat-conversion
+      -Wfor-loop-analysis
+      -Wformat-non-iso
+      -Wformat-type-confusion
+      -Wheader-hygiene
+      -Widiomatic-parentheses
+      -Winfinite-recursion
+      -Wlogical-op-parentheses
+      -Wmethod-signatures
+      -Wmissing-noreturn
+      -Wmissing-variable-declarations
+      -Wmove
+      -Wnon-gcc
+      -Wnon-virtual-dtor
+      -Wnull-pointer-arithmetic
+      -Wnullable-to-nonnull-conversion
+      -Wover-aligned
+      -Woverlength-strings
+      -Woverloaded-virtual
+      -Woverriding-method-mismatch
+      -Wpragma-pack
+      -Wpragma-pack-suspicious-include
+      -Wquoted-include-in-framework-header
+      -Wrange-loop-analysis
+      -Wredundant-move
+      -Wredundant-parens
+      -Wreserved-id-macro
+      -Wreturn-std-move
+      -Wself-assign
+      -Wself-move
+      -Wsemicolon-before-method-body
+      -Wshadow-all
+      -Wshift-sign-overflow
+      -Wsometimes-uninitialized
+      -Wstatic-in-inline
+      -Wstrict-prototypes
+      -Wstrict-selector-match
+      -Wstring-conversion
+      -Wsuper-class-method-mismatch
+      -Wswitch-enum
+      -Wtautological-bitwise-compare
+      -Wtautological-constant-in-range-compare
+      -Wtautological-overlap-compare
+      -Wtautological-type-limit-compare
+      -Wtautological-unsigned-enum-zero-compare
+      -Wtautological-unsigned-zero-compare
+      -Wunneeded-internal-declaration
+      -Wunneeded-member-function
+      -Wunreachable-code-aggressive
+      -Wunused-label
+      -Wunused-lambda-capture
+      -Wunused-local-typedef
+      -Wunused-variable
+      -Wvla-extension
+      -Wzero-length-array
+
+      -Wno-sign-conversion
+      -Wno-shorten-64-to-32
+      )
+  endif()
+else()
+  message(FATAL_ERROR "Unsupported compiler!")
 endif()
 
 include_directories(

--- a/disasmtool_lix/disasm.hpp
+++ b/disasmtool_lix/disasm.hpp
@@ -43,25 +43,9 @@ typedef size_t SIZE_T;
 #define MAX_PATH  255
 #endif
 
-#ifndef __in
-#define __in
-#endif
-
-#ifndef __out
-#define __out
-#endif
-
-#ifndef __inout
-#define __inout
-#endif
-
 // Main disasm header file.
 // #include "bdshemu.h"
 #include "bddisasm.h"
-
-#undef __in
-#undef __out
-#undef __inout
 
 #include <unistd.h>
 #include <time.h>

--- a/disasmtool_lix/disasmtool.cpp
+++ b/disasmtool_lix/disasmtool.cpp
@@ -13,7 +13,7 @@
 
 static const long NSEC_PER_SEC = (1000ULL * 1000ULL * 1000ULL);
 
-const char *gSpaces[16] =
+static const char *gSpaces[16] =
 {
     "",
     "  ",
@@ -40,7 +40,7 @@ struct options {
     size_t size;
     size_t count;
 
-    int bits;
+    uint8_t bits;
 
     uint8_t vendor;
     bool no_color;
@@ -68,7 +68,7 @@ extern "C"
     {
         return vsnprintf(buffer, sizeOfBuffer, format, argptr);
     }
-    
+
     void *
     nd_memset(void *s, int c, size_t n)
     {
@@ -113,7 +113,7 @@ static bool _hexstring_to_bytes(options &opts)
         if (pair == "0x" || pair == "0X" || pair == "\\x")
             continue;
 
-        auto b = std::strtoul(pair.c_str(), &end_ptr, 16);
+        auto b = static_cast<uint8_t>(std::strtoul(pair.c_str(), &end_ptr, 16));
 
         size_t conv_size = static_cast<size_t>(end_ptr - pair.c_str());
 
@@ -486,7 +486,7 @@ size_t disassemble(options &opts)
     size_t icount = 0, miss_count = 0, ibytes = 0;
     size_t rel_rip = opts.offset;
     size_t total_disasm = 0;
-    auto bytes = reinterpret_cast<uint8_t *>(opts.bytes.get());
+    auto bytes = opts.bytes.get();
     auto disasm_size = std::min(opts.actual_size - opts.offset, opts.size);
 
     while ((total_disasm < disasm_size) && (icount < opts.count)) {
@@ -657,7 +657,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    opts.bits = parser.get<int>("bits");
+    opts.bits = parser.get<uint8_t>("bits");
     opts.interactive = parser.get<bool>("interactive");
     opts.comm = parser.get<bool>("comm");
     opts.offset = _get_hex_opt(parser, "offset");


### PR DESCRIPTION
- The build wasn't checking properly for the compiler (was checking for C, but this is a CXX project).
- Also added a few more compiler options for GCC 9 and Clang 10 (and fixed the warnings that those options generated)