### PR TITLE
Improved stack string detection heuristic: only consider registers wh…

### DIFF
--- a/inc/bdshemu/bdshemu.h
+++ b/inc/bdshemu/bdshemu.h
@@ -130,7 +130,11 @@ typedef struct _SHEMU_CONTEXT
     uint64_t        MmxRegisters[ND_MAX_MMX_REGS];
 
     // SSE registers state. 32 x 64 bytes = 2048 bytes for the SSE registers. Can be provided on input, if needed.
-    uint8_t         SseRegisters[ND_MAX_SSE_REGS * ND_MAX_REGISTER_SIZE]; 
+    uint8_t         SseRegisters[ND_MAX_SSE_REGS * ND_MAX_REGISTER_SIZE];
+
+    // General purpose registers write bitmap. After the first write, a register will be marked dirty in here. 
+    // Should be 0 on input.
+    uint16_t        DirtyGprBitmap;
 
     // Operating mode (ND_CODE_16, ND_CODE_32 or ND_CODE_64). Must be provided as input.
     uint8_t         Mode;

--- a/inc/version.h
+++ b/inc/version.h
@@ -7,6 +7,6 @@
 
 #define DISASM_VERSION_MAJOR        1
 #define DISASM_VERSION_MINOR        28
-#define DISASM_VERSION_REVISION     0
+#define DISASM_VERSION_REVISION     1
 
 #endif // DISASM_VER_H

--- a/pybddisasm/setup.py
+++ b/pybddisasm/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup, Command, Extension, Distribution
 from codecs import open
 
 VERSION = (0, 1, 2)
-LIBRARY_VERSION = (1, 28, 0)
+LIBRARY_VERSION = (1, 28, 1)
 LIBRARY_INSTRUX_SIZE = 856
 
 packages = ['pybddisasm']


### PR DESCRIPTION
Improved stack string detection heuristic: only consider registers which have been modified during emulation; registers which were provided as "input" can be ignored, as they most likely contain addresses or other data relevant to the emulated code. We are only interested in string dynamically built during our emulation.
