### PR TITLE
Add copy-pastable python example

### DIFF
--- a/pybddisasm/README.md
+++ b/pybddisasm/README.md
@@ -19,6 +19,26 @@ from pybddisasm.bddisasm import *
 instr = nd_decode_ex2(buff, arch, arch, arch, vendor, current_rip)
 ```
 
+## Example
+
+```python
+from pybddisasm.bddisasm import *
+from sys import *
+
+buff = b"\x55\x48\x8b\x05\xb8\x13\x00\x00"
+offset = 0
+
+while offset < getsizeof(buff):
+    instr = nd_decode_ex2(buff[offset:], 64, 64, 64)
+
+    if instr is None:
+        break
+
+    print(instr.Text)
+
+    offset += instr.Length
+```
+
 ## Pip
 
 Use pip to install the package:


### PR DESCRIPTION
The buffer is the same as in the Capstone example (https://www.capstone-engine.org/lang_python.html).

Interestingly the disassembly slightly differs compared to Capstone, with bddisasm we get:

```
PUSH      rbp
MOV       rax, qword ptr [rel 0x13bf]
```