### PR TITLE
Automatically add binaries to a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,11 @@ jobs:
       if: ${{ github.event_name == 'release' }}
       run: |
         del bin\x64\Release\*.idb
+        del bin\x64\Release\*.iobj
+        del bin\x64\Release\*.ipdb
         del bin\Win32\Release\*.idb
+        del bin\Win32\Release\*.iobj
+        del bin\Win32\Release\*.ipdb
         tar.exe -acf x64-windows-release.zip bin\x64\Release
         tar.exe -acf x86-windows-release.zip bin\Win32\Release
     - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         cd build
         make disasmtool
-        ./disasmtool -h
+        ../../bin/x64/Release/disasmtool -h
         cd -
     - name: Install setuptools
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,14 @@ jobs:
     - name: Build bddisasm and bdshemu for Win32
       run: MSBuild /t:Rebuild /p:Configuration=Release /p:Platform=Win32 bddisasm.sln
     - name: Zip binaries
+      if: ${{ github.event_name == 'release' }}
       run: |
         del bin\x64\Release\*.idb
         del bin\Win32\Release\*.idb
         tar.exe -acf x64-windows-release.zip bin\x64\Release
         tar.exe -acf x86-windows-release.zip bin\Win32\Release
-      if: ${{ github.event_name == 'release' }}
     - name: Release
+      if: ${{ github.event_name == 'release' }}
       uses: AButler/upload-release-assets@v2.0
       with:
         files: 'x64-windows-release.zip;x86-windows-release.zip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build bddisasm and bdshemu
-      run: |
-        mkdir build
-        cd build
-        cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr
-        make bddisasm bdshemu
-        cd -
     - name: Install rapidjson
       uses: actions/checkout@master
       with:
@@ -52,6 +45,13 @@ jobs:
         sudo make install
         cd ..
         cd ..
+    - name: Build bddisasm and bdshemu
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr
+        make bddisasm bdshemu
+        cd -
     - name: Build disasmtool_lix
       run: |
         cd build
@@ -67,6 +67,12 @@ jobs:
         cd pybddisasm
         python3 setup.py build
         cd ..
+    - name: Create package
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        cd build
+        make package
+        cd -
     - name: Release
       if: ${{ github.event_name == 'release' }}
       uses: AButler/upload-release-assets@v2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - 'bddisasm_test/**'
       - 'bdshemu_test/**'
       - 'LICENSE'
+  release:
+    types: [published]
+  
 
 jobs:
   Linux-build:
@@ -81,6 +84,19 @@ jobs:
       run: MSBuild /t:Rebuild /p:Configuration=Release /p:Platform=x64 bddisasm.sln
     - name: Build bddisasm and bdshemu for Win32
       run: MSBuild /t:Rebuild /p:Configuration=Release /p:Platform=Win32 bddisasm.sln
+    - name: Zip binaries
+      run: |
+        del bin\x64\Release\*.idb
+        del bin\Win32\Release\*.idb
+        tar.exe -acf x64-windows-release.zip bin\x64\Release
+        tar.exe -acf x86-windows-release.zip bin\Win32\Release
+      if: ${{ github.event_name == 'release' }}
+    - name: Release
+      uses: AButler/upload-release-assets@v2.0
+      with:
+        files: 'x64-windows-release.zip;x86-windows-release.zip'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      
 
   Code-checks:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr
+        cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
         make bddisasm bdshemu -j$(nproc)
         cd -
     - name: Build disasmtool_lix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..
-        make
+        cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr
+        make bddisasm bdshemu
         cd -
     - name: Install rapidjson
       uses: actions/checkout@master
@@ -54,13 +54,9 @@ jobs:
         cd ..
     - name: Build disasmtool_lix
       run: |
-        cd disasmtool_lix
-        mkdir _build
-        cd _build
-        cmake ..
-        make -j$(nproc)
-        cd ..
-        cd ..
+        cd build
+        make disasmtool
+        cd -
     - name: Install setuptools
       run: |
         python3 -m pip install --upgrade pip
@@ -71,6 +67,12 @@ jobs:
         cd pybddisasm
         python3 setup.py build
         cd ..
+    - name: Release
+      if: ${{ github.event_name == 'release' }}
+      uses: AButler/upload-release-assets@v2.0
+      with:
+        files: 'build/*.deb'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   Windows-build:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,12 @@ jobs:
         mkdir build
         cd build
         cmake .. -DINCLUDE_TOOL=y -DCMAKE_INSTALL_PREFIX=/usr
-        make bddisasm bdshemu
+        make bddisasm bdshemu -j$(nproc)
         cd -
     - name: Build disasmtool_lix
       run: |
         cd build
-        make disasmtool
-        ../../bin/x64/Release/disasmtool -h
+        make disasmtool -j$(nproc)
         cd -
     - name: Install setuptools
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       run: |
         cd build
         make disasmtool
+        ./disasmtool -h
         cd -
     - name: Install setuptools
       run: |

--- a/bddisasm.sln
+++ b/bddisasm.sln
@@ -30,11 +30,15 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Debug|Win32.ActiveCfg = Debug|Win32
+		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Debug|Win32.Build.0 = Debug|Win32
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Debug|x64.ActiveCfg = Debug|x64
+		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Debug|x64.Build.0 = Debug|x64
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.DebugKernel|Win32.ActiveCfg = Debug|Win32
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.DebugKernel|x64.ActiveCfg = Debug|x64
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Release|Win32.ActiveCfg = Release|Win32
+		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Release|Win32.Build.0 = Release|Win32
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Release|x64.ActiveCfg = Release|x64
+		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.Release|x64.Build.0 = Release|x64
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.ReleaseKernel|Win32.ActiveCfg = Release|Win32
 		{94F1B65D-3305-4CCB-9DF1-50B56900D867}.ReleaseKernel|x64.ActiveCfg = Release|x64
 		{3653AA19-048B-410E-B5C4-FF78E1D84C12}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/disasmtool_lix/CMakeLists.txt
+++ b/disasmtool_lix/CMakeLists.txt
@@ -254,7 +254,6 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE
   ${DISASM_DIRECTORY}/inc
-  ${DISASM_DIRECTORY}/inc/bdshemu
   ${DISASM_DIRECTORY}/bddisasm/include
   )
 

--- a/disasmtool_lix/CMakeLists.txt
+++ b/disasmtool_lix/CMakeLists.txt
@@ -63,7 +63,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE
   -g3
   -gdwarf-4
   -grecord-gcc-switches
-  -march=native
+  -march=nehalem
   -fno-omit-frame-pointer
   # -fsanitize=leak
   # -fsanitize=address


### PR DESCRIPTION
This should trigger overtime a new release is published, adding the following build artefacts to it:

- a `.deb` file containing the Linux libraries, public headers, and `disasmtool`.
- two ZIPs, one with the Windows 32-bit libraries and `disasmtool`, the other with the Windows 64-bit binaries. 

All builds are Release builds.

A sample release can be found [here](https://github.com/ianichitei/bddisasm/releases/tag/test-4).

The Windows ZIPs do not include the public headers. Chrome triggers a warning due to `disasmtool.exe` being included in the archives. This probably happens because it doesn't have a signature. 