### PR TITLE
ci: Install Windows SDK 18362 when building on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Install rapidjson
@@ -83,6 +84,7 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Add msbuild to PATH
@@ -113,6 +115,7 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Add msbuild to PATH
@@ -131,6 +134,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Install cppcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Install rapidjson
@@ -84,7 +83,6 @@ jobs:
 
     runs-on: windows-latest
 
-    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Add msbuild to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
+    - name: Setup Windows SDK
+      uses: fbactions/setup-winsdk@v1
+      with:
+        winsdk-build-version: 18362
     - name: Build all
       run: MSBuild /t:Rebuild /p:Configuration=Release /p:Platform=x64 bddisasm.sln
     - name: Build bddisasm and bdshemu for Win32

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    permissions: read-all
     steps:
     - uses: actions/checkout@v2
     - name: Set LIBCLANG_PATH


### PR DESCRIPTION
It looks like Windows SDK 18362 is no longer available on Windows build runners. This is related to the move to Windows Server 2022, which no longer has this version installed ([details](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md#installed-windows-sdks)).

We're currently installing it ourselves, but this makes the take a longer time (setting up the SDK takes around 2 or 3 minutes). The correct solution would be to update the SDK version to a newer version, or even better: set it to always use the latest version available. 
