### PR TITLE
Fix `clang-cl` and `mingw` builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif ()
 
 # These are shared by bddisasm and bdshemu.
-if (NOT MSVC)
+if (MSVC OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
+    set(BDDISASM_COMMON_COMPILE_OPTIONS /W4 /WX)
+else ()
     set(BDDISASM_COMMON_COMPILE_OPTIONS
         "$<$<CONFIG:Release>:-U_FORTIFY_SOURCE>"
         "$<$<CONFIG:Release>:-D_FORTIFY_SOURCE=2>"
@@ -68,8 +70,6 @@ if (NOT MSVC)
         -gdwarf-4
         -grecord-gcc-switches
         -march=westmere)
-else ()
-    set(BDDISASM_COMMON_COMPILE_OPTIONS /W4 /WX)
 endif ()
 
 set(BDDISASM_PUBLIC_HEADERS
@@ -91,6 +91,7 @@ set(BDDISASM_INSTALL_INCLUDE_DIR
 
 include(CheckFunctionExists)
 include(CheckSymbolExists)
+include(CheckCCompilerFlag)
 
 add_library(
     bddisasm STATIC
@@ -171,7 +172,9 @@ target_include_directories(bddisasm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOU
 target_link_libraries(bdshemu PUBLIC bddisasm)
 
 target_compile_options(bdshemu PRIVATE ${BDDISASM_COMMON_COMPILE_OPTIONS})
-if (NOT MSVC)
+
+check_c_compiler_flag(-maes HAS_MAES)
+if (HAS_MAES)
     target_compile_options(bdshemu PRIVATE -maes)
 endif ()
 

--- a/bddisasm/bddisasm.c
+++ b/bddisasm/bddisasm.c
@@ -3550,7 +3550,7 @@ cleanup_and_exit:
 //
 // NdGetVectorLength
 //
-static __forceinline NDSTATUS
+static inline NDSTATUS
 NdGetVectorLength(
     INSTRUX *Instrux
     )
@@ -3605,7 +3605,7 @@ NdGetVectorLength(
 //
 // NdGetAddrAndOpMode
 //
-static __forceinline NDSTATUS
+static inline NDSTATUS
 NdGetAddrAndOpMode(
     INSTRUX *Instrux
     )
@@ -3636,7 +3636,7 @@ NdGetAddrAndOpMode(
 //
 // NdGetEffectiveOpMode
 //
-static __forceinline NDSTATUS
+static inline NDSTATUS
 NdGetEffectiveOpMode(
     INSTRUX *Instrux
     )
@@ -3792,7 +3792,7 @@ NdPostProcessEvex(
 //
 // NdValidateInstruction
 //
-static __forceinline NDSTATUS
+static inline NDSTATUS
 NdValidateInstruction(
     INSTRUX *Instrux
     )

--- a/bddisasm/include/nd_crt.h
+++ b/bddisasm/include/nd_crt.h
@@ -11,10 +11,6 @@
 #define UNREFERENCED_PARAMETER(P)       ((void)(P))
 #endif
 
-#if !defined(_MSC_VER)
-# define __forceinline       inline __attribute__((always_inline))
-#endif // _MSC_VER
-
 // By default, an integrator is expected to provide nd_vsnprintf_s and nd_strcat_s.
 // bddisasm needs both for NdToText, while bdshemu needs nd_vsnprintf_s for emulation tracing.
 // If BDDISASM_NO_FORMAT is defined at compile time these requirements are removed. Instruction formatting will no

--- a/disasmtool/CMakeLists.txt
+++ b/disasmtool/CMakeLists.txt
@@ -27,14 +27,21 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     endif ()
 endif ()
 
-if (NOT MSVC)
+if (MSVC OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
+    target_compile_options(disasmtool PRIVATE /W4 /WX)
+
+    if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        target_compile_options(disasmtool PRIVATE -Wno-format)
+    endif ()
+else ()
     target_compile_options(
         disasmtool
         PRIVATE -Wall
                 -Wno-unknown-pragmas
                 -Wextra
                 -Wshadow
-                -Wformat-security
+                -Wno-format
+                -Wno-cast-function-type
                 -Wstrict-overflow=2
                 -Wstrict-prototypes
                 -Wwrite-strings
@@ -46,7 +53,6 @@ if (NOT MSVC)
                 -Wno-discarded-qualifiers
                 -Wnull-dereference
                 -Wduplicated-cond
-                -Werror=format-security
                 -Werror=implicit-function-declaration
                 -pipe
                 -fwrapv
@@ -59,6 +65,4 @@ if (NOT MSVC)
                 -gdwarf-4
                 -grecord-gcc-switches
                 -march=westmere)
-else ()
-    target_compile_options(disasmtool PRIVATE /W4 /WX)
 endif ()

--- a/disasmtool/disasmtool.c
+++ b/disasmtool/disasmtool.c
@@ -594,7 +594,7 @@ INT32 regstr_to_idx(
         "r8",  "r9",  "r10", "r11", "r12", "r13", "r14", "r15"
     };
 
-    for (INT32 i = 0; i < ARRAYSIZE(reg64); i++)
+    for (INT32 i = 0; i < (INT32)ARRAYSIZE(reg64); i++)
     {
         if (!_stricmp(Reg, reg64[i]))
         {
@@ -1417,7 +1417,7 @@ void set_shemuctx_file(
 
         // first element is the register
         regIdx = regstr_to_idx(regStr);
-        if (regIdx < 0 || regIdx >= ARRAYSIZE(Options->ShemuRegs))
+        if (regIdx < 0 || regIdx >= (INT32)ARRAYSIZE(Options->ShemuRegs))
         {
             if (!_stricmp(regStr, "rip"))
             {


### PR DESCRIPTION
This should fix #77.

I replaced `__forceinline` with `inline`. `mingw` [complains](https://mingw-w64-public.narkive.com/u6ZqKlU8/about-the-error-error-multiple-storage-classes-in-declaration-specifiers) when it encounteres `static __forceinline` and `ifdef`ing this problem away is an ugly solution.

`__forceinline` was used on 4 functions: `NdGetVectorLength`, `NdGetAddrAndOpMode`, `NdGetEffectiveOpMode`, and `NdValidateInstruction` - all called only once from `NdDecodeWithContext`. The first 2 functions are still inlined on 64-bit MSVC Release builds, but the other 2 are not. This should not have a negative impact.

For Linux builds, using `clang`, only `NdGetAddrAndOpMode` and `NdGetEffectiveOpMode` seem to be inlined.