### PR TITLE
Fix test runner on Linux

### DIFF
--- a/bddisasm_test/README.md
+++ b/bddisasm_test/README.md
@@ -9,4 +9,4 @@ The `test_all.py` script will iterate all the test folders, and it will run bddi
 The result file will be compared with the output of the test run. If they are not the same, the test will fail.
 Note that bddisasm will be run with the `-exi` option, in order to dump all possible information about the instructions.
 
-NOTE: This test will assume `disasm` is in the path. Works on Windows only.
+NOTE: This test will assume `disasm` is in the path.

--- a/bddisasm_test/test_all.py
+++ b/bddisasm_test/test_all.py
@@ -65,7 +65,7 @@ def test_dir(dir):
     global total_tests
     global failed_tests
     
-    for f in glob.glob('%s\\*.test' % dir):
+    for f in glob.glob('%s/*.test' % dir):
         base, _ = os.path.splitext(f)
         
         tst_file = f
@@ -107,7 +107,7 @@ def test_dir(dir):
         os.remove(tmp_file)
         
 def regenerate(dir): 
-    for f in glob.glob('%s\\*.test' % dir):
+    for f in glob.glob('%s/*.test' % dir):
         base, _ = os.path.splitext(f)
         
         tst_file = f
@@ -128,7 +128,7 @@ def regenerate(dir):
         os.system('disasm -exi %s -f %s >%s' % (mod, tst_file, res_file))
 
 if __name__ == "__main__":
-    for dn in glob.glob("x86\\*"):
+    for dn in glob.glob("x86/*"):
         if not os.path.isdir(dn):
             continue
         if "regenerate" in sys.argv:


### PR DESCRIPTION
Fix the globs to work on Linux and remove the note about it not working from README.

Why does the test runner expect a binary named `disasm` when by default it's created as `disasmtool`?
