### PR TITLE
fix gcc warning in NdFetchData

### DIFF
--- a/bddisasm/bdx86_decoder.c
+++ b/bddisasm/bdx86_decoder.c
@@ -88,7 +88,6 @@ NdGetVersion(
 
 }
 
-
 //
 // NdFetchData
 //
@@ -98,11 +97,19 @@ NdFetchData(
     ND_UINT8 Size
     )
 {
-    return (4 == Size) ? ND_FETCH_32(Buffer) :
-           (1 == Size) ? ND_FETCH_8(Buffer) :
-           (8 == Size) ? ND_FETCH_64(Buffer) :
-           (2 == Size) ? ND_FETCH_16(Buffer) :
-           0;
+    switch (Size) 
+    {
+    case 1:
+        return ND_FETCH_8(Buffer);
+    case 2:
+        return ND_FETCH_16(Buffer);
+    case 4:
+        return ND_FETCH_32(Buffer);
+    case 8:
+        return ND_FETCH_64(Buffer);
+    default:
+        return 0;
+    }
 }
 
 


### PR DESCRIPTION
this PR fixes this compiler warning: bddisasm_crt.c bdx86_decoder.c
bdx86_decoder.c: In function ‘NdFetchData’:
bdx86_decoder.c:104:12: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  104 |            (2 == Size) ? ND_FETCH_16(Buffer) :
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |            0;
      |            ~
bdx86_formatter.c
bdx86_helpers.c
Disasm library in ../bin/x64/Debug/libbddisasm.a
bddisasm_crt.c
bdx86_decoder.c
bdx86_decoder.c: In function ‘NdFetchData’:
bdx86_decoder.c:104:12: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  104 |            (2 == Size) ? ND_FETCH_16(Buffer) :
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |            0;
      |            ~
bdx86_formatter.c
bdx86_helpers.c
Disasm library in ../bin/x64/Release/libbddisasm.a
bdshemu.c
bdshemu_x86.c
Shemu library in ../bin/x64/Debug/libbdshemu.a
bdshemu.c
bdshemu_x86.c
Shemu library in ../bin/x64/Release/libbdshemu.a