### PR TITLE
More optimizations

### DIFF
--- a/bddisasm/bdx86_decoder.c
+++ b/bddisasm/bdx86_decoder.c
@@ -4427,11 +4427,19 @@ NdDecodeWithContext(
     Instrux->EncMode = ND_ENCM_LEGACY;  // Assume legacy encoding by default.
 
     // Fetch the instruction bytes.
-    for (opIndex = 0; 
-         opIndex < ((Size < ND_MAX_INSTRUCTION_LENGTH) ? Size : ND_MAX_INSTRUCTION_LENGTH); 
-         opIndex++)
+    if (Size < ND_MAX_INSTRUCTION_LENGTH)
     {
-        Instrux->InstructionBytes[opIndex] = Code[opIndex];
+        for (opIndex = 0; opIndex < Size; opIndex++)
+        {
+            Instrux->InstructionBytes[opIndex] = Code[opIndex];
+        }
+    }
+    else
+    {
+        for (opIndex = 0; opIndex < ND_MAX_INSTRUCTION_LENGTH; opIndex++)
+        {
+            Instrux->InstructionBytes[opIndex] = Code[opIndex];
+        }
     }
 
     if (gPrefixesMap[Instrux->InstructionBytes[0]] != ND_PREF_CODE_NONE)


### PR DESCRIPTION
GCC was putting a conditional move in the copy loop for some reason. The second one is less certain and seems to be highly sensitive to changes.
```
    N           Min           Max        Median           Avg        Stddev
x  30      18039044      18336971      18278984      18267936     61730.367
+  30      18453057      18728267      18672697      18658935     56689.819
Difference at 95.0% confidence
	390999 +/- 30634.3
	2.14036% +/- 0.167694%
	(Student's t, pooled s = 59263.7)
```
