### PR TITLE
bdshemu: Fix edge case with unsupported instrs

### DIFF
--- a/bdshemu/bdshemu_x86.c
+++ b/bdshemu/bdshemu_x86.c
@@ -1793,13 +1793,6 @@ ShemuX86Emulate(
         nd_memzero(&dst, sizeof(dst));
         nd_memzero(&src, sizeof(src));
 
-        // The stop flag has been set, this means we've reached a valid instruction, but that instruction cannot be
-        // emulated (for example, SYSCALL, INT, system instructions, etc).
-        if (stop)
-        {
-            return SHEMU_ABORT_CANT_EMULATE;
-        }
-
         // If we already have a detection and we wish to stop on detections, do so now.
         if ((0 != Context->Flags) && (0 != (Context->Options & SHEMU_OPT_STOP_ON_EXPLOIT)))
         {
@@ -1942,7 +1935,7 @@ ShemuX86Emulate(
                 }
             }
 
-            continue;
+            goto post_emulate;
         }
 
         // This flag can only be set for APX instructions.
@@ -3556,6 +3549,14 @@ check_far_branch:
             return SHEMU_ABORT_INSTRUX_NOT_SUPPORTED;
 
             break;
+        }
+
+post_emulate:
+        // The stop flag has been set, this means we've reached a valid instruction, but that instruction cannot be
+        // emulated (for example, SYSCALL, INT, system instructions, etc).
+        if (stop)
+        {
+            return SHEMU_ABORT_CANT_EMULATE;
         }
     }
 

--- a/bdshemu_test/x86/basic/test_32_callf1.result
+++ b/bdshemu_test/x86/basic/test_32_callf1.result
@@ -8,5 +8,5 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  9A000002003300                  CALLF     0x0033:0x00020000
-Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_callf2.result
+++ b/bdshemu_test/x86/basic/test_32_callf2.result
@@ -62,6 +62,6 @@ IP: 0x000000000020000f  89851C000000                    MOV       dword ptr [ebp
         RIP = 0x0000000000200015 RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200015  FF9D1C000000                    CALLF     fword ptr [ebp+0x1c]
         Memory LOAD, address 0x000000000020001c, size 6, value 1B0020003300
-Emulation terminated with status 0x0000000a, flags: 0x82, 0 NOPs, 0 NULLs, 7 total instructions, 6 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x82, 0 NOPs, 0 NULLs, 6 total instructions, 6 unique instructions
         SHEMU_FLAG_LOAD_RIP
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_iret.result
+++ b/bdshemu_test/x86/basic/test_32_iret.result
@@ -54,5 +54,5 @@ IP: 0x0000000000200008  83042405                        ADD       dword ptr [esp
         RIP = 0x000000000020000c RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000c  CF                              IRETD
         Memory LOAD, address 0x00000000001fdff4, size 12, value 0D0020003300000002020000
-Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_jmpf1.result
+++ b/bdshemu_test/x86/basic/test_32_jmpf1.result
@@ -8,5 +8,5 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  EA000002003300                  JMPF      0x0033:0x00020000
-Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_jmpf2.result
+++ b/bdshemu_test/x86/basic/test_32_jmpf2.result
@@ -62,6 +62,6 @@ IP: 0x000000000020000f  89851C000000                    MOV       dword ptr [ebp
         RIP = 0x0000000000200015 RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200015  FFAD1C000000                    JMPF      fword ptr [ebp+0x1c]
         Memory LOAD, address 0x000000000020001c, size 6, value 1B0020003300
-Emulation terminated with status 0x0000000a, flags: 0x82, 0 NOPs, 0 NULLs, 7 total instructions, 6 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x82, 0 NOPs, 0 NULLs, 6 total instructions, 6 unique instructions
         SHEMU_FLAG_LOAD_RIP
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_loadrip02.result
+++ b/bdshemu_test/x86/basic/test_32_loadrip02.result
@@ -30,5 +30,5 @@ IP: 0x0000000000200013  61                              POPAD
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200014 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200014  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_32_loadseg01.result
+++ b/bdshemu_test/x86/basic/test_32_loadseg01.result
@@ -72,4 +72,4 @@ IP: 0x0000000000200009  90                              NOP
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000a RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000a  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 8 total instructions, 7 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 7 total instructions, 7 unique instructions

--- a/bdshemu_test/x86/basic/test_32_neg.result
+++ b/bdshemu_test/x86/basic/test_32_neg.result
@@ -68,4 +68,4 @@ IP: 0x000000000020000d  89C8                            MOV       eax, ecx
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000f RFLAGS = 0x0000000000000247   CF:1 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000f  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 8 total instructions, 7 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 7 total instructions, 7 unique instructions

--- a/bdshemu_test/x86/basic/test_32_retf.result
+++ b/bdshemu_test/x86/basic/test_32_retf.result
@@ -43,5 +43,5 @@ IP: 0x0000000000200007  83042405                        ADD       dword ptr [esp
         RIP = 0x000000000020000b RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000b  CB                              RETF
         Memory LOAD, address 0x00000000001fdff8, size 8, value 0C00200033000000
-Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x80, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions
         SHEMU_FLAG_HEAVENS_GATE

--- a/bdshemu_test/x86/basic/test_32_stack_pivot1.result
+++ b/bdshemu_test/x86/basic/test_32_stack_pivot1.result
@@ -28,4 +28,4 @@ IP: 0x0000000000200001  94                              XCHG      esp, eax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200002 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200002  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_32_stack_pivot3.result
+++ b/bdshemu_test/x86/basic/test_32_stack_pivot3.result
@@ -80,5 +80,5 @@ IP: 0x0000000000200013  94                              XCHG      esp, eax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200014 RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200014  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 1 NOPs, 0 NULLs, 9 total instructions, 8 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 1 NOPs, 0 NULLs, 8 total instructions, 8 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_32_stack_pivot4.result
+++ b/bdshemu_test/x86/basic/test_32_stack_pivot4.result
@@ -70,6 +70,6 @@ IP: 0x0000000000200012  94                              XCHG      esp, eax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200013 RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200013  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x102, 1 NOPs, 0 NULLs, 8 total instructions, 7 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x102, 1 NOPs, 0 NULLs, 7 total instructions, 7 unique instructions
         SHEMU_FLAG_LOAD_RIP
         SHEMU_FLAG_STACK_PIVOT

--- a/bdshemu_test/x86/basic/test_32_sys01.result
+++ b/bdshemu_test/x86/basic/test_32_sys01.result
@@ -8,5 +8,5 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  0F34                            SYSENTER
-Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions
         SHEMU_FLAG_SYSCALL

--- a/bdshemu_test/x86/basic/test_64_adc01.result
+++ b/bdshemu_test/x86/basic/test_64_adc01.result
@@ -158,4 +158,4 @@ IP: 0x0000000000200015  14FE                            ADC       al, 0xfe
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200017 RFLAGS = 0x0000000000000247   CF:1 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200017  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 17 total instructions, 16 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 16 total instructions, 16 unique instructions

--- a/bdshemu_test/x86/basic/test_64_basic07.result
+++ b/bdshemu_test/x86/basic/test_64_basic07.result
@@ -8,4 +8,4 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions

--- a/bdshemu_test/x86/basic/test_64_bitscan01.result
+++ b/bdshemu_test/x86/basic/test_64_bitscan01.result
@@ -548,4 +548,4 @@ IP: 0x00000000002000b6  480FBDC0                        BSR       rax, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002000ba RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002000ba  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 56 total instructions, 55 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 55 total instructions, 55 unique instructions

--- a/bdshemu_test/x86/basic/test_64_branch2.result
+++ b/bdshemu_test/x86/basic/test_64_branch2.result
@@ -59,5 +59,5 @@ IP: 0x0000000000200011  C606CC                          MOV       byte ptr [rsi]
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200014 RFLAGS = 0x0000000000000247   CF:1 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200014  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x4, 0 NOPs, 0 NULLs, 7 total instructions, 6 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x4, 0 NOPs, 0 NULLs, 6 total instructions, 6 unique instructions
         SHEMU_FLAG_WRITE_SELF

--- a/bdshemu_test/x86/basic/test_64_branch4.result
+++ b/bdshemu_test/x86/basic/test_64_branch4.result
@@ -49,5 +49,5 @@ IP: 0x000000000020000b  C606CC                          MOV       byte ptr [rsi]
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000e RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000e  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x4, 0 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x4, 0 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions
         SHEMU_FLAG_WRITE_SELF

--- a/bdshemu_test/x86/basic/test_64_branch_boundary01.result
+++ b/bdshemu_test/x86/basic/test_64_branch_boundary01.result
@@ -50,5 +50,5 @@ IP: 0x0000000000200007  90                              NOP
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200008 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200008  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_64_branch_boundary02.result
+++ b/bdshemu_test/x86/basic/test_64_branch_boundary02.result
@@ -120,4 +120,4 @@ IP: 0x000000000020000f  90                              NOP
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200010 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200010  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 13 total instructions, 12 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 12 total instructions, 12 unique instructions

--- a/bdshemu_test/x86/basic/test_64_bswap01.result
+++ b/bdshemu_test/x86/basic/test_64_bswap01.result
@@ -98,4 +98,4 @@ IP: 0x0000000000200026  480FC8                          BSWAP     rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200029 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200029  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 11 total instructions, 10 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 10 total instructions, 10 unique instructions

--- a/bdshemu_test/x86/basic/test_64_cmov.result
+++ b/bdshemu_test/x86/basic/test_64_cmov.result
@@ -48,4 +48,4 @@ IP: 0x000000000020000e  0F45CB                          CMOVNZ    ecx, ebx
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200011 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200011  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions

--- a/bdshemu_test/x86/basic/test_64_cmpxchg01.result
+++ b/bdshemu_test/x86/basic/test_64_cmpxchg01.result
@@ -158,4 +158,4 @@ IP: 0x0000000000200036  0FB1CA                          CMPXCHG   edx, ecx
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200039 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200039  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 17 total instructions, 16 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 16 total instructions, 16 unique instructions

--- a/bdshemu_test/x86/basic/test_64_div.result
+++ b/bdshemu_test/x86/basic/test_64_div.result
@@ -28,4 +28,4 @@ IP: 0x000000000020000a  6631C0                          XOR       ax, ax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000d RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000d  66F7F0                          DIV       ax
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_div2.result
+++ b/bdshemu_test/x86/basic/test_64_div2.result
@@ -28,4 +28,4 @@ IP: 0x0000000000200005  F7D7                            NOT       edi
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200007 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200007  F7FF                            IDIV      edi
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_imul01.result
+++ b/bdshemu_test/x86/basic/test_64_imul01.result
@@ -118,4 +118,4 @@ IP: 0x0000000000200021  69C200000001                    IMUL      eax, edx, 0x01
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200027 RFLAGS = 0x0000000000000a03   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:1
 IP: 0x0000000000200027  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 13 total instructions, 12 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 12 total instructions, 12 unique instructions

--- a/bdshemu_test/x86/basic/test_64_imul02.result
+++ b/bdshemu_test/x86/basic/test_64_imul02.result
@@ -168,4 +168,4 @@ IP: 0x000000000020004f  48F7EA                          IMUL      rdx
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200052 RFLAGS = 0x0000000000000a03   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:1
 IP: 0x0000000000200052  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 18 total instructions, 17 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 17 total instructions, 17 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip02.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip02.result
@@ -50,5 +50,5 @@ IP: 0x000000000020000a  488B0424                        MOV       rax, qword ptr
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000e RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000e  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_64_loadrip03.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip03.result
@@ -40,5 +40,5 @@ IP: 0x0000000000200007  48032C24                        ADD       rbp, qword ptr
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000b RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000b  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_64_loadrip04.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip04.result
@@ -30,4 +30,4 @@ IP: 0x0000000000200006  C3                              RETN
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200005 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200005  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip05.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip05.result
@@ -30,4 +30,4 @@ IP: 0x0000000000200005  48833C2400                      CMP       qword ptr [rsp
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000a RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000a  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip06.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip06.result
@@ -41,4 +41,4 @@ IP: 0x0000000000200007  48010424                        ADD       qword ptr [rsp
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000b RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000b  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip07.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip07.result
@@ -63,4 +63,4 @@ IP: 0x000000000020000f  488B0404                        MOV       rax, qword ptr
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200013 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200013  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 7 total instructions, 6 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 6 total instructions, 6 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip08.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip08.result
@@ -30,4 +30,4 @@ IP: 0x0000000000200006  FF2424                          JMP       qword ptr [rsp
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200005 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200005  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_loadrip09.result
+++ b/bdshemu_test/x86/basic/test_64_loadrip09.result
@@ -40,5 +40,5 @@ IP: 0x0000000000200008  48AD                            LODSQ
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000a RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000a  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x2, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions
         SHEMU_FLAG_LOAD_RIP

--- a/bdshemu_test/x86/basic/test_64_loadseg01.result
+++ b/bdshemu_test/x86/basic/test_64_loadseg01.result
@@ -28,4 +28,4 @@ IP: 0x0000000000200002  8EC0                            MOV       es, eax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200004 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200004  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_movszx.result
+++ b/bdshemu_test/x86/basic/test_64_movszx.result
@@ -186,4 +186,4 @@ IP: 0x000000000020004f  0FB64608                        MOVZX     eax, byte ptr 
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200053 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200053  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 19 total instructions, 18 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 18 total instructions, 18 unique instructions

--- a/bdshemu_test/x86/basic/test_64_popcnt01.result
+++ b/bdshemu_test/x86/basic/test_64_popcnt01.result
@@ -368,4 +368,4 @@ IP: 0x00000000002000af  F3480FB8C8                      POPCNT    rcx, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002000b4 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002000b4  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 38 total instructions, 37 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 37 total instructions, 37 unique instructions

--- a/bdshemu_test/x86/basic/test_64_r0_sidt.result
+++ b/bdshemu_test/x86/basic/test_64_r0_sidt.result
@@ -18,5 +18,5 @@ IP: 0x0000000000200000  90                              NOP
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200001 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200001  0F010C24                        SIDT      tbyte ptr [rsp]
-Emulation terminated with status 0x0000000a, flags: 0x1000000000, 1 NOPs, 0 NULLs, 3 total instructions, 2 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x1000000000, 1 NOPs, 0 NULLs, 2 total instructions, 2 unique instructions
         SHEMU_FLAG_SIDT

--- a/bdshemu_test/x86/basic/test_64_rcl01.result
+++ b/bdshemu_test/x86/basic/test_64_rcl01.result
@@ -1208,4 +1208,4 @@ IP: 0x00000000002000c9  C0D01E                          RCL       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002000cc RFLAGS = 0x0000000000000203   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002000cc  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 122 total instructions, 121 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 121 total instructions, 121 unique instructions

--- a/bdshemu_test/x86/basic/test_64_rcr01.result
+++ b/bdshemu_test/x86/basic/test_64_rcr01.result
@@ -1208,4 +1208,4 @@ IP: 0x00000000002000c9  C0D81E                          RCR       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002000cc RFLAGS = 0x0000000000000203   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002000cc  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 122 total instructions, 121 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 121 total instructions, 121 unique instructions

--- a/bdshemu_test/x86/basic/test_64_rdtsc.result
+++ b/bdshemu_test/x86/basic/test_64_rdtsc.result
@@ -68,4 +68,4 @@ IP: 0x0000000000200009  0F31                            RDTSC
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000b RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000b  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 8 total instructions, 7 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 7 total instructions, 7 unique instructions

--- a/bdshemu_test/x86/basic/test_64_rol01.result
+++ b/bdshemu_test/x86/basic/test_64_rol01.result
@@ -608,4 +608,4 @@ IP: 0x0000000000200063  C0C01E                          ROL       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200066 RFLAGS = 0x0000000000000203   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200066  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 62 total instructions, 61 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 61 total instructions, 61 unique instructions

--- a/bdshemu_test/x86/basic/test_64_ror01.result
+++ b/bdshemu_test/x86/basic/test_64_ror01.result
@@ -608,4 +608,4 @@ IP: 0x0000000000200063  C0C81E                          ROR       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200066 RFLAGS = 0x0000000000000203   CF:1 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200066  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 62 total instructions, 61 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 61 total instructions, 61 unique instructions

--- a/bdshemu_test/x86/basic/test_64_sar01.result
+++ b/bdshemu_test/x86/basic/test_64_sar01.result
@@ -328,4 +328,4 @@ IP: 0x0000000000200033  C0F81E                          SAR       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200036 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200036  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 34 total instructions, 33 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 33 total instructions, 33 unique instructions

--- a/bdshemu_test/x86/basic/test_64_sbb01.result
+++ b/bdshemu_test/x86/basic/test_64_sbb01.result
@@ -288,4 +288,4 @@ IP: 0x0000000000200028  1C20                            SBB       al, 0x20
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020002a RFLAGS = 0x0000000000000287   CF:1 PF:1 AF:0 ZF:0 SF:1 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020002a  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 30 total instructions, 29 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 29 total instructions, 29 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shl01.result
+++ b/bdshemu_test/x86/basic/test_64_shl01.result
@@ -608,4 +608,4 @@ IP: 0x0000000000200063  C0E01E                          SHL       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200066 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200066  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 62 total instructions, 61 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 61 total instructions, 61 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shld01.result
+++ b/bdshemu_test/x86/basic/test_64_shld01.result
@@ -128,4 +128,4 @@ IP: 0x000000000020004a  480FA4D841                      SHLD      rax, rbx, 0x41
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020004f RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020004f  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 14 total instructions, 13 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 13 total instructions, 13 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shld02.result
+++ b/bdshemu_test/x86/basic/test_64_shld02.result
@@ -38,4 +38,4 @@ IP: 0x000000000020000a  660FA4D81F                      SHLD      ax, bx, 0x1f
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000f RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000f  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shr01.result
+++ b/bdshemu_test/x86/basic/test_64_shr01.result
@@ -608,4 +608,4 @@ IP: 0x0000000000200063  C0E81E                          SHR       al, 0x1e
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200066 RFLAGS = 0x0000000000000a46   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:1
 IP: 0x0000000000200066  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 62 total instructions, 61 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 61 total instructions, 61 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shrd01.result
+++ b/bdshemu_test/x86/basic/test_64_shrd01.result
@@ -128,4 +128,4 @@ IP: 0x000000000020004a  480FACD841                      SHRD      rax, rbx, 0x41
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020004f RFLAGS = 0x0000000000000287   CF:1 PF:1 AF:0 ZF:0 SF:1 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020004f  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 14 total instructions, 13 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 13 total instructions, 13 unique instructions

--- a/bdshemu_test/x86/basic/test_64_shrd02.result
+++ b/bdshemu_test/x86/basic/test_64_shrd02.result
@@ -38,4 +38,4 @@ IP: 0x000000000020000a  660FACD81F                      SHRD      ax, bx, 0x1f
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000f RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000f  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions

--- a/bdshemu_test/x86/basic/test_64_sidt.result
+++ b/bdshemu_test/x86/basic/test_64_sidt.result
@@ -18,4 +18,4 @@ IP: 0x0000000000200000  90                              NOP
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200001 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200001  0F010C24                        SIDT      tbyte ptr [rsp]
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 3 total instructions, 2 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 2 total instructions, 2 unique instructions

--- a/bdshemu_test/x86/basic/test_64_stack_pivot1.result
+++ b/bdshemu_test/x86/basic/test_64_stack_pivot1.result
@@ -28,4 +28,4 @@ IP: 0x0000000000200001  4894                            XCHG      rsp, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200003 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200003  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 4 total instructions, 3 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 3 total instructions, 3 unique instructions

--- a/bdshemu_test/x86/basic/test_64_stack_pivot3.result
+++ b/bdshemu_test/x86/basic/test_64_stack_pivot3.result
@@ -48,4 +48,4 @@ IP: 0x000000000020000b  4894                            XCHG      rsp, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000d RFLAGS = 0x0000000000000206   CF:0 PF:1 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000d  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 6 total instructions, 5 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 5 total instructions, 5 unique instructions

--- a/bdshemu_test/x86/basic/test_64_stack_pivot4.result
+++ b/bdshemu_test/x86/basic/test_64_stack_pivot4.result
@@ -38,5 +38,5 @@ IP: 0x0000000000200008  4894                            XCHG      rsp, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x000000000020000a RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x000000000020000a  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x100, 1 NOPs, 0 NULLs, 5 total instructions, 4 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x100, 1 NOPs, 0 NULLs, 4 total instructions, 4 unique instructions
         SHEMU_FLAG_STACK_PIVOT

--- a/bdshemu_test/x86/basic/test_64_sys01.result
+++ b/bdshemu_test/x86/basic/test_64_sys01.result
@@ -8,5 +8,5 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  0F05                            SYSCALL
-Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions
         SHEMU_FLAG_SYSCALL

--- a/bdshemu_test/x86/basic/test_64_sys02.result
+++ b/bdshemu_test/x86/basic/test_64_sys02.result
@@ -8,5 +8,5 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  CD80                            INT       0x80
-Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x10, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions
         SHEMU_FLAG_SYSCALL

--- a/bdshemu_test/x86/basic/test_64_sys03.result
+++ b/bdshemu_test/x86/basic/test_64_sys03.result
@@ -8,4 +8,4 @@
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200000 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200000  CD33                            INT       0x33
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 2 total instructions, 1 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 1 total instructions, 1 unique instructions

--- a/bdshemu_test/x86/basic/test_64_zcnt01.result
+++ b/bdshemu_test/x86/basic/test_64_zcnt01.result
@@ -968,4 +968,4 @@ IP: 0x00000000002001af  F3480FBCC8                      TZCNT     rcx, rax
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002001b4 RFLAGS = 0x0000000000000242   CF:0 PF:0 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002001b4  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 98 total instructions, 97 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 1 NOPs, 0 NULLs, 97 total instructions, 97 unique instructions

--- a/bdshemu_test/x86/basic_apx/test_64_apx01.result
+++ b/bdshemu_test/x86/basic_apx/test_64_apx01.result
@@ -89,4 +89,4 @@ IP: 0x000000000020002d  D5668A34FA                      MOV       r30b, byte ptr
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x00000000000000bd R31 = 0x0000000000000001
         RIP = 0x0000000000200032 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200032  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 10 total instructions, 9 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 9 total instructions, 9 unique instructions

--- a/bdshemu_test/x86/basic_apx/test_64_apx02.result
+++ b/bdshemu_test/x86/basic_apx/test_64_apx02.result
@@ -62,4 +62,4 @@ IP: 0x0000000000200013  D5195F                          POPP      r31
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0xbdbdbdbdbdbdbdbd
         RIP = 0x0000000000200016 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200016  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 7 total instructions, 6 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 6 total instructions, 6 unique instructions

--- a/bdshemu_test/x86/basic_apx/test_64_apx03.result
+++ b/bdshemu_test/x86/basic_apx/test_64_apx03.result
@@ -268,4 +268,4 @@ IP: 0x00000000002000ba  626C7D1C01DE                    ADDNF     ax, r22w, r27w
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x00000000002000c0 RFLAGS = 0x0000000000000246   CF:0 PF:1 AF:0 ZF:1 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x00000000002000c0  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 28 total instructions, 27 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 27 total instructions, 27 unique instructions

--- a/bdshemu_test/x86/basic_apx/test_64_apx04.result
+++ b/bdshemu_test/x86/basic_apx/test_64_apx04.result
@@ -83,4 +83,4 @@ IP: 0x0000000000200028  5E                              POP       rsi
         R28 = 0x0000000000000000 R29 = 0x0000000000000000 R30 = 0x0000000000000000 R31 = 0x0000000000000000
         RIP = 0x0000000000200029 RFLAGS = 0x0000000000000202   CF:0 PF:0 AF:0 ZF:0 SF:0 TF:0 IF:1 DF:0 OF:0
 IP: 0x0000000000200029  CC                              INT3
-Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 9 total instructions, 8 unique instructions
+Emulation terminated with status 0x0000000a, flags: 0x0, 0 NOPs, 0 NULLs, 8 total instructions, 8 unique instructions


### PR DESCRIPTION
Fixes https://github.com/bitdefender/bddisasm/issues/106

Adjusted this PR to be more consistent with the code style.

Note: `InstructionsCount` is incremented before stop on exploit is checked. If shellcode is detected after `n` instructions, `InstructionsCount` will be `n+1`, even though instruction `n+1` was never emulated. `Context->InstructionsCount++` could be done after the stop on exploit check in order to be more accurate, but this is nitpicking.