### PR TITLE
Change the definition of shemu_printf so that unused parameters are removed from the compiled binary

### DIFF
--- a/bdshemu/bdshemu.c
+++ b/bdshemu/bdshemu.c
@@ -14,7 +14,7 @@
 //
 // shemu_internal_printf - simple version
 //
-
+#ifndef BDDISASM_NO_FORMAT
 void
 shemu_internal_printf(
     SHEMU_CONTEXT *Context,
@@ -39,6 +39,18 @@ shemu_internal_printf(
 
     Context->Log(buff, Context->AuxData);
 }
+#else
+void
+shemu_internal_printf(
+    SHEMU_CONTEXT *Context,
+    char *formatstring,
+    ...
+    )
+{
+    UNREFERENCED_PARAMETER(Context);
+    UNREFERENCED_PARAMETER(formatstring);
+}
+#endif // !BDDISASM_NO_FORMAT
 
 
 //

--- a/bdshemu/bdshemu.c
+++ b/bdshemu/bdshemu.c
@@ -12,11 +12,11 @@
 
 
 //
-// shemu_printf - simple version
+// shemu_internal_printf - simple version
 //
-#ifndef BDDISASM_NO_FORMAT
+
 void
-shemu_printf(
+shemu_internal_printf(
     SHEMU_CONTEXT *Context,
     char *formatstring,
     ...
@@ -39,18 +39,6 @@ shemu_printf(
 
     Context->Log(buff, Context->AuxData);
 }
-#else
-void
-shemu_printf(
-    SHEMU_CONTEXT *Context,
-    char *formatstring,
-    ...
-    )
-{
-    UNREFERENCED_PARAMETER(Context);
-    UNREFERENCED_PARAMETER(formatstring);
-}
-#endif // !BDDISASM_NO_FORMAT
 
 
 //

--- a/bdshemu/include/bdshemu_common.h
+++ b/bdshemu/include/bdshemu_common.h
@@ -11,6 +11,14 @@
 #define _Analysis_assume_(x)
 #endif
 
+#ifndef BDDISASM_NO_FORMAT
+#define shemu_printf(Context, formatstring, ...) shemu_internal_printf(Context, formatstring, __VA_ARGS__)
+#else
+#define shemu_printf(Context, formatstring, ...) { UNREFERENCED_PARAMETER(Context); \
+                                                   UNREFERENCED_PARAMETER(formatstring); \
+                                                   UNREFERENCED_PARAMETER(__VA_ARGS__); \
+                                                 }
+#endif
 
 // The SHELLBMP and STACKBMP are two bitmaps which hold the state of each shellcode byte and each stack byte.
 // Inside SHELLBMP, we store whether a shellcode byte has been fetched for execution or not, and whether it was 
@@ -65,7 +73,7 @@
 
 
 void
-shemu_printf(
+shemu_internal_printf(
     SHEMU_CONTEXT *Context,
     char *formatstring,
     ...

--- a/bdshemu/include/bdshemu_common.h
+++ b/bdshemu/include/bdshemu_common.h
@@ -15,7 +15,7 @@
 #ifndef BDDISASM_NO_FORMAT
 #define shemu_printf(Context, formatstring, ...) shemu_internal_printf(Context, formatstring, __VA_ARGS__)
 #else
-#define shemu_printf(Context, formatstring, ...) do { (void)formatstring; shemu_internal_printf(Context, NULL, __VA_ARGS__); } while (0)
+#define shemu_printf(Context, formatstring, ...) do { (void)formatstring; shemu_internal_printf(Context, ND_NULL, __VA_ARGS__); } while (0)
 #endif
 
 // The SHELLBMP and STACKBMP are two bitmaps which hold the state of each shellcode byte and each stack byte.

--- a/bdshemu/include/bdshemu_common.h
+++ b/bdshemu/include/bdshemu_common.h
@@ -11,13 +11,11 @@
 #define _Analysis_assume_(x)
 #endif
 
+
 #ifndef BDDISASM_NO_FORMAT
 #define shemu_printf(Context, formatstring, ...) shemu_internal_printf(Context, formatstring, __VA_ARGS__)
 #else
-#define shemu_printf(Context, formatstring, ...) { UNREFERENCED_PARAMETER(Context); \
-                                                   UNREFERENCED_PARAMETER(formatstring); \
-                                                   UNREFERENCED_PARAMETER(__VA_ARGS__); \
-                                                 }
+#define shemu_printf(Context, formatstring, ...) do { (void)formatstring; shemu_internal_printf(Context, NULL, __VA_ARGS__); } while (0)
 #endif
 
 // The SHELLBMP and STACKBMP are two bitmaps which hold the state of each shellcode byte and each stack byte.


### PR DESCRIPTION
With the current implementation of shemu_printf, when BDDISASM_NO_FORMAT is defined, the parameters of shemu_printf are present in the output binary even though they are not used. This is due to the fact that shemu_printf is defined as a function.

For example, strings like "        Loop BREAK from RIP 0x%016llx, TARGET 0x%016llx, ITER %llu\n" can be found in the binary.
I am working on an embedded device where I do not have a lot of memory and it does not make sense in this context to embed these strings if they are not used.

This PR introduces a new declaration of shemu_printf based on a macro that enables the compilers to remove these strings from the output binary and reduce its size.