### PR TITLE
Keep some compile flags private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,25 @@ jobs:
         ninja
         cd -
 
+  Windows-clang-build:
+
+    runs-on: winodws-latest
+
+    permissions: read-all
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Clang
+      uses: egor-tensin/setup-clang@ef434b41eb33a70396fb336b1bae39c76d740c3d # v1.4
+    - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # master
+    - name: Build libs
+      run: |
+        mkdir build
+        cd build
+        cmake .. -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        # disasmtool can not be built with clang on Windows at the moment.
+        ninja bddisasm bdshemu
+        cd -
+
   Macos-build:
 
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
   Windows-clang-build:
 
-    runs-on: winodws-latest
+    runs-on: windows-latest
 
     permissions: read-all
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,43 +42,54 @@ endif ()
 
 # These are shared by bddisasm and bdshemu.
 if (MSVC OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
-    set(BDDISASM_COMMON_COMPILE_OPTIONS /W4 /WX)
+    if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+        set(BDDISASM_COMMON_COMPILE_OPTIONS /W4 /WX)
+    endif ()
 else ()
     set(BDDISASM_COMMON_COMPILE_OPTIONS
         "$<$<CONFIG:Release>:-U_FORTIFY_SOURCE>"
         "$<$<CONFIG:Release>:-D_FORTIFY_SOURCE=2>"
-        -Wall
         -Wno-unknown-pragmas
-        -Wextra
-        -Wshadow
-        -Wformat-security
-        -Wstrict-overflow=2
-        -Wstrict-prototypes
-        -Wwrite-strings
-        -Wshadow
-        -Winit-self
         -Wno-unused-function
         -Wno-multichar
         -Wno-incompatible-pointer-types
         -Wnull-dereference
-        -Werror=format-security
-        -Werror=implicit-function-declaration
         -pipe
         -fwrapv
         -fno-strict-aliasing
         -fstack-protector-strong
-        -fno-omit-frame-pointer
-        -ffunction-sections
-        -fdata-sections
-        -g3
-        -gdwarf-4
-        -grecord-gcc-switches
-        -march=native)
+    )
+
+    if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+        list(APPEND BDDISASM_COMMON_COMPILE_OPTIONS
+            -Wall
+            -Wextra
+            -Wshadow
+            -Wformat-security
+            -Wstrict-overflow=2
+            -Wstrict-prototypes
+            -Wwrite-strings
+            -Winit-self
+            -Werror=format-security
+            -Werror=implicit-function-declaration
+            -fno-omit-frame-pointer
+            -g3
+            -gdwarf-4
+            -grecord-gcc-switches
+            -march=native
+        )
+    endif ()
 
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
         list(APPEND BDDISASM_COMMON_COMPILE_OPTIONS
-            -Wduplicated-cond
-            -Wno-discarded-qualifiers)
+            -Wno-discarded-qualifiers
+        )
+
+        if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+            list(APPEND BDDISASM_COMMON_COMPILE_OPTIONS
+                -Wduplicated-cond
+            )
+        endif ()
     endif ()
 endif ()
 

--- a/inc/bddisasm_types.h
+++ b/inc/bddisasm_types.h
@@ -5,6 +5,10 @@
 #ifndef BDDISASM_TYPES_H
 #define BDDISASM_TYPES_H
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#endif
 
 #if defined(_MSC_VER) || defined(__ICC) || defined(__INTEL_COMPILER)
 
@@ -103,5 +107,9 @@ typedef ND_UINT8 ND_BOOL;
 #endif
 #define ND_TRUE     (1)
 #define ND_FALSE    (0)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif // BDDISASM_TYPES_H

--- a/inc/bdx86_core.h
+++ b/inc/bdx86_core.h
@@ -13,6 +13,11 @@
 #include "bdx86_constants.h"
 #include "bdx86_cpuidflags.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1953,6 +1958,10 @@ NdInitContext(
 // #pragma warning(default: 4201) // Nonstandard extension used: nameless struct/union.
 #ifdef _MSC_VER
 #pragma warning(pop)
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 #endif // BDX86_CORE_H


### PR DESCRIPTION
This changes the build scripts to set some compiler options only when this is the top-level project, solving the issues raised in #113. When consumed as a library the user will have more control over how `bddisasm` and `bdshemu` are built. Pre-built binaries will still be compiled as before. 

I also added a clang build step on Windows and disabled some clang specific warnings.