### PR TITLE
bdshemu: Fix MOVS/STOS/LODS/SCAS/CMPS silent no-op at MaxInstructionsCount boundary

### DIFF
--- a/bdshemu/bdshemu_x86.c
+++ b/bdshemu/bdshemu_x86.c
@@ -2640,8 +2640,9 @@ check_far_branch:
         case ND_INS_LODS:
         case ND_INS_STOS:
         case ND_INS_MOVS:
-            // Fetch the rCX register, which is the third operand in case of repeated instructions.
-            while (Context->InstructionsCount < Context->MaxInstructionsCount)
+            // do/while: outer loop already gated this dispatch on a budget slot,
+            // so iteration #1 must run even at MaxInstructionsCount == 1.
+            do
             {
                 // Get the RCX value.
                 GET_OP(Context, 2, &dst);
@@ -2667,12 +2668,13 @@ check_far_branch:
                 }
 
                 Context->InstructionsCount++;
-            }
+            } while (Context->InstructionsCount < Context->MaxInstructionsCount);
             break;
 
         case ND_INS_SCAS:
         case ND_INS_CMPS:
-            while (Context->InstructionsCount < Context->MaxInstructionsCount)
+            // Same budget contract as MOVS above.
+            do
             {
                 // Get the RCX value.
                 GET_OP(Context, 2, &dst);
@@ -2717,7 +2719,7 @@ check_far_branch:
                 }
 
                 Context->InstructionsCount++;
-            }
+            } while (Context->InstructionsCount < Context->MaxInstructionsCount);
             break;
 
         case ND_INS_MUL:


### PR DESCRIPTION
The MOVS/STOS/LODS/SCAS/CMPS handlers gate their body on:
`while (Context->InstructionsCount < Context->MaxInstructionsCount)`, 
but the outer dispatch loop has already incremented `InstructionsCount` to the slot it spent on this dispatch. When those values are equal at that moment (e.g. when `MaxInstructionsCount == 1`), the body is skipped entirely and `ShemuEmulate` returns `SHEMU_SUCCESS` with no memory move, no RSI/RDI advance, no RCX decrement, and no flag update.

Switched both handlers to `do { ... } while (...)` so the first
iteration always runs.